### PR TITLE
Refactor viscous entry into function and remove globals

### DIFF
--- a/decode_design_apply.m
+++ b/decode_design_apply.m
@@ -1,4 +1,8 @@
-function [geom, sh, orf, hyd, therm, num, ga] = decode_design_apply(ga, geom, sh, orf, hyd, therm, num)
+function [geom, sh, orf, hyd, therm, num, ga] = decode_design_apply(ga, geom, sh, orf, hyd, therm, num, LOG)
+    if nargin < 8 || isempty(LOG)
+        LOG = struct('verbose_decode', false);
+    end
+
     % --- set_id'i güvene al (string/char gelirse sayıya çevir) ---
     set_id = ga.design_set;
     if isstring(set_id) || ischar(set_id)
@@ -71,13 +75,8 @@ therm.resFactor = x(10);
     ga.lb=lb; ga.ub=ub; ga.int_idx=int_idx; ga.names=names; ga.x_use=x;
     % ... (x hazırlandıktan SONRA)
     xdisp = strjoin( compose('%.3g', x(:).'), ', ' );  % 9 sayı -> "a, b, c..."
- % (Sessiz mod) — yalnızca LOG.verbose_decode=true ise yaz
-try
-    if evalin('base','exist(''LOG'',''var'')') && evalin('base','isstruct(LOG)') ...
-            && evalin('base','isfield(LOG,''verbose_decode'') && LOG.verbose_decode')
+    % (Sessiz mod) — yalnızca LOG.verbose_decode=true ise yaz
+    if isstruct(LOG) && isfield(LOG,'verbose_decode') && LOG.verbose_decode
         fprintf('GA decode: set=%s | x_use = [%s]\n', num2str(ga.design_set), xdisp);
     end
-catch
-    % base workspace erişimi yoksa sessizce geç
-end
 end

--- a/simulate.m
+++ b/simulate.m
@@ -1,5 +1,8 @@
 function resp = simulate(design_set, x, mu_mult, t, ag, ...
-    M, Cstr, K, n, geom, sh, orf, hyd, therm, num, cfg)
+    M, Cstr, K, n, geom, sh, orf, hyd, therm, num, cfg, LOG)
+if nargin < 17 || isempty(LOG)
+    LOG = struct('verbose_decode', false);
+end
 design_set = double(design_set);
     if ~isfinite(design_set) || ~ismember(design_set,[1 2 3])
         design_set = 1;
@@ -17,7 +20,7 @@ design_set = double(design_set);
 
         % ---- GA decode (varsa)
         ga_local = struct('enable',~isempty(x),'design_set',design_set,'x',x);
-        [geom, sh, orf, hyd, therm, num, ~] = decode_design_apply(ga_local, geom, sh, orf, hyd, therm, num);
+        [geom, sh, orf, hyd, therm, num, ~] = decode_design_apply(ga_local, geom, sh, orf, hyd, therm, num, LOG);
 
         % ---- Türetilenler
         geom.Ap   = pi*geom.Dp^2/4;


### PR DESCRIPTION
## Summary
- Convert `viscous.m` into a callable `viscous` function and move configuration defaults into `default_params`.
- Replace global `LOG` and `PARETO` with function inputs/outputs and propagate logging through parameters.
- Update `simulate` and `decode_design_apply` signatures to accept logging struct and adjust calls accordingly.

## Testing
- `octave -qf --eval "disp(1)"` *(fails: command not found)*
- `matlab -batch "disp(1)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae367d2d7c8328bea9b97026da308d