### PR TITLE
Reduce response diagnostics memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # GA
+
+## Memory usage
+
+`simulate` formerly stored the full diagnostic structure in `resp.diag`, which could be large. It now retains only the `cav_frac_t` time series, reducing memory needs of the response object. For a representative run with 1000 time steps and 3 stories, this change lowers memory from about 168 kB to 8 kB (~95% reduction).
+

--- a/simulate.m
+++ b/simulate.m
@@ -82,7 +82,8 @@ xD(~isfinite(xD)) = 0;  aD(~isfinite(aD)) = 0;
                       'cav_frac_p95',cav_p95,'Q_abs_p95',diag.Q_abs_p95, ...
                       'T_oil_max',Toil_max);
 
-        resp.diag = diag;   % cav_frac_t dahil tüm zaman serisi diagnostiklerini dışarı ver
+        % Yalnızca gerekli tanı alanlarını saklayarak bellek kullanımını azalt
+        resp.diag = struct('cav_frac_t', diag.cav_frac_t);
 
         % Zarf kuvvet (hikaye bazında max → zaman serisi)
         F_story_env = max(abs(diag.F_story),[],2);   % Nt x 1


### PR DESCRIPTION
## Summary
- Store only required cavitation diagnostics from `simulate` instead of full `diag`
- Document memory footprint reduction in README

## Testing
- `octave -q --eval "N=1000; n=4; diag.drift=rand(N,n-1); diag.F_story=rand(N,n-1); diag.dP_orf_time=rand(N,n-1); diag.dP_orf_time_max=max(diag.dP_orf_time,[],2); diag.T_oil=rand(N,1); diag.T_steel=rand(N,1); diag.mu_t=rand(N,1); diag.E_cum=rand(N,1); diag.cav_frac_t=rand(N,1); diag.dP_q50=rand(N,1); diag.dP_q95=rand(N,1); diag.Q_abs_med=rand(N,1); diag.Q_abs_p95=rand(N,1); diag.cav_margin_t=rand(N,1); diag.cav_margin_min=rand(N,1); resp_full.diag=diag; resp_min.diag=struct('cav_frac_t',diag.cav_frac_t); whos('resp_full'); whos('resp_min');"`


------
https://chatgpt.com/codex/tasks/task_e_68af0f2342908328adb71fd67c45dce3