### PR TITLE
Remove unused fixnf utility

### DIFF
--- a/simulate.m
+++ b/simulate.m
@@ -61,8 +61,7 @@ if ~isfield(diag,'dP_orf_time_max') || any(~isfinite(diag.dP_orf_time_max))
     end
 end
 
-% Ana dizilerde tekil NaN/Inf temizliği (fail yerine yumuşat)
-fixnf = @(A) (A + 0.*A);          % sınıfı korumak için num trick
+% Ana dizilerde tekil NaN/Inf temizliği (fail yerine sıfırlama)
 xD(~isfinite(xD)) = 0;  aD(~isfinite(aD)) = 0;
 
         % ---- Standart çıktı paketi


### PR DESCRIPTION
## Summary
- drop leftover `fixnf` helper from NaN/Inf cleanup in `simulate.m`
- clarify NaN/Inf cleanup comment to reflect zeroing approach

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b04201fd188328bcf7d9a02f9e3e0b