### PR TITLE
Remove unused helpers from viscous.m

### DIFF
--- a/viscous.m
+++ b/viscous.m
@@ -1780,19 +1780,6 @@ function [xbest, fbest, output, pop, scores, exitflag] = ga_call_compat(fhandle,
         end
     end
 end
-function v = aux_if(field)
-    v = NaN;
-    try, v = output.bestfval; catch, end %#ok<*CTCH>
-end
-function v = cons_detail_if(which)
-    v = NaN;
-    try
-        % compute from last simulate if elinizde varsa; basit placeholder
-        if strcmpi(which,'E_ratio'), v = NaN; end
-        if strcmpi(which,'cav95'),   v = NaN; end
-    catch
-    end
-end
 
 % =============================== Alt Yapı ===============================
 function f = compact_log_wrapper(x, inner_fitfun)
@@ -1903,15 +1890,7 @@ function [x,a_rel] = lin_MCK_consistent(t, ag, M, C, K)
 end
 
 
-% --- NOTE: Artık 4. opsiyonel çıktı "v" döndürülebilir (mevcut çağrılar çalışmaya devam eder)
-function Jp = local_JPattern(n)
-% Güvenli, tutucu (full) JPattern — küçük boyutlarda performans yeterli
-% İstersen kendi bant/blok yapını sonra geri koyarsın.
-    Ns = n - 1;
-    Ntot = 2*n + 2*Ns + Ns + 2;
-    Jp = sparse(ones(Ntot, Ntot));  % tüm girişlerin potansiyel nonzero olduğunu varsay
-end
-
+  
 function [J1, J2] = compute_objectives_split( ...
     src, obj, tail_sec, ...
     t_rawX,t_rawY,a_rawX,a_rawY,t_sclX,t_sclY,a_sclX,a_sclY, ...


### PR DESCRIPTION
## Summary
- prune unused helper functions from `viscous.m`
- drop local Jacobian pattern function `local_JPattern`

## Testing
- `octave --version` *(fails: command not found)*
- `sudo apt-get install -y octave` *(fails: ca-certificates-java post-install script error)*

------
https://chatgpt.com/codex/tasks/task_e_68b04373bc848328804d0f87a245811c