### PR TITLE
Add resFactor parameter to GA design set 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # GA
+
+## Design Sets
+
+- **Set 3:** `[n_orf, Cd0, mu_ref, b_mu, beta0, b_beta, hA_os, dP_cap, Vmin_fac, resFactor]`

--- a/decode_design_apply.m
+++ b/decode_design_apply.m
@@ -55,7 +55,7 @@ x = max(lb, min(ub, x));
             hyd.K_leak  = x(8);
             therm.resFactor = x(9);
         otherwise % 3
-            % [n_orf, Cd0, mu_ref, b_mu, beta0, b_beta, hA_os, dP_cap, Vmin_fac]
+            % [n_orf, Cd0, mu_ref, b_mu, beta0, b_beta, hA_os, dP_cap, Vmin_fac, resFactor]
             orf.n_orf   = x(1);
             orf.Cd0     = x(2);
             therm.mu_ref= x(3);
@@ -65,7 +65,7 @@ x = max(lb, min(ub, x));
             therm.hA_os = x(7);
             num.dP_cap  = x(8);
             hyd.Vmin_fac= x(9);
-therm.resFactor = x(10);
+            therm.resFactor = x(10);
     end
 
     ga.lb=lb; ga.ub=ub; ga.int_idx=int_idx; ga.names=names; ga.x_use=x;

--- a/ga_get_bounds.m
+++ b/ga_get_bounds.m
@@ -15,11 +15,11 @@ function [lb,ub,int_idx,names] = ga_get_bounds(set_id)
             names = {'n_orf','Cd0','CdInf','Rec','p_exp','cav_sf','Lh','K_leak','resFactor'};
 
         otherwise % 3  (n_orf SABİT=2)
-            % [n_orf, Cd0, mu_ref, b_mu, beta0, b_beta, hA_os, dP_cap, Vmin_fac]
+            % [n_orf, Cd0, mu_ref, b_mu, beta0, b_beta, hA_os, dP_cap, Vmin_fac, resFactor]
             lb = [2, 0.64, 0.6, -0.012, 1.2e9, -6e-3, 450, 3e8, 0.90,  10];
             ub = [2, 0.68, 1.2, -0.007, 2.2e9, -2e-3, 800, 6e8, 0.95, 18];
             int_idx = 1; % n_orf (sabit ama interface için sorun değil)
-            names = {'n_orf','Cd0','mu_ref','b_mu','beta0','b_beta','hA_os','dP_cap','Vmin_fac'};
+            names = {'n_orf','Cd0','mu_ref','b_mu','beta0','b_beta','hA_os','dP_cap','Vmin_fac','resFactor'};
 
     end
 end


### PR DESCRIPTION
## Summary
- include `resFactor` in design set 3 bounds and parameter names
- document `resFactor` usage in decode and README

## Testing
- `apt-get install -y octave` *(fails: ca-certificates-java post-installation error)*

------
https://chatgpt.com/codex/tasks/task_e_68b04a131e288328bfe6997ca40e62d0