### PR TITLE
Use boolean flag for spring free length

### DIFF
--- a/ensure_cfg_defaults.m
+++ b/ensure_cfg_defaults.m
@@ -20,4 +20,9 @@ function cfg = ensure_cfg_defaults(cfg)
     if ~isfield(cfg.PF,'t_on'), cfg.PF.t_on = NaN; end
     if ~isfield(cfg.PF,'tau'),  cfg.PF.tau  = 2.5; end
     if ~isfield(cfg.PF,'gain'), cfg.PF.gain = 0.6; end
+    % constraint defaults
+    if ~isfield(cfg,'cons') || ~isstruct(cfg.cons), cfg.cons = struct(); end
+    if ~isfield(cfg.cons,'spring') || ~isstruct(cfg.cons.spring), cfg.cons.spring = struct(); end
+    if ~isfield(cfg.cons.spring,'use_fixed_length'), cfg.cons.spring.use_fixed_length = false; end
+    if ~isfield(cfg.cons.spring,'L_free_fixed'), cfg.cons.spring.L_free_fixed = NaN; end
 end

--- a/viscous.m
+++ b/viscous.m
@@ -76,8 +76,9 @@ cons.on.fail_bigM      = true;    % K9: Simülasyon başarısızsa büyük ceza
 % Eşikler / limitler
 cons.spring.tau_allow   = 300e6;  % [Pa] yay çeliği için tipik, gerekirse güncelle
 cons.spring.lambda_max  = 12.0;   % boy/çap sınırı
-cons.spring.L_free_mode = 'auto'; % 'auto' veya 'fixed'
-cons.spring.L_free_fix  = NaN;    % 'fixed' için metre cinsinden serbest boy
+% true -> serbest yay boyu sabit değerden alınır; false -> boşluk oranına göre hesaplanır
+cons.spring.use_fixed_length = false;   % varsayılan: false
+cons.spring.L_free_fixed     = NaN;     % [m] use_fixed_length=true ise kullanılan serbest boy
 cons.spring.L_free_auto_fac = 2.2; % 'auto' modda L_free ≈ fac * L_gap
 
 cons.stroke.util_factor = 0.90;   % izinli strok = 0.90*L_gap
@@ -1573,8 +1574,8 @@ end
 
     % K2: burkulma/serbest boy oranı
     if cons.on.spring_slender
-        if strcmpi(cons.spring.L_free_mode,'fixed') && isfinite(cons.spring.L_free_fix)
-            L_free = cons.spring.L_free_fix;
+        if cons.spring.use_fixed_length && isfinite(cons.spring.L_free_fixed)
+            L_free = cons.spring.L_free_fixed;
         else
             L_free = cons.spring.L_free_auto_fac * geom.Lgap; % yaklaşıklama
         end


### PR DESCRIPTION
## Summary
- Replace `cons.spring.L_free_mode` and `L_free_fix` with boolean `use_fixed_length` and numeric `L_free_fixed`
- Apply new flag in spring slenderness calculation
- Provide default config values for new spring options

## Testing
- `apt-get update` *(fails: gpgv required)*
- `octave --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b04edd85448328bc8060d0d687810c