### PR TITLE
Add auto PF timing defaults and usage notes

### DIFF
--- a/ensure_cfg_defaults.m
+++ b/ensure_cfg_defaults.m
@@ -16,11 +16,12 @@ function cfg = ensure_cfg_defaults(cfg)
     end
     % PF struct
     if ~isfield(cfg,'PF') || ~isstruct(cfg.PF), cfg.PF = struct(); end
-    if ~isfield(cfg.PF,'mode'),      cfg.PF.mode = 'ramp'; end
-    if ~isfield(cfg.PF,'auto_t_on'), cfg.PF.auto_t_on = true; end
-    if ~isfield(cfg.PF,'t_on'),      cfg.PF.t_on = 0; end
-    if ~isfield(cfg.PF,'tau'),       cfg.PF.tau  = 2.5; end
-    if ~isfield(cfg.PF,'gain'),      cfg.PF.gain = 0.6; end
+    % auto_t_on=true -> t_on = t5 + 0.5 via set_pf_ton_if_auto
+    cfg.PF.mode      = getfield_default(cfg.PF,'mode','ramp');
+    cfg.PF.auto_t_on = getfield_default(cfg.PF,'auto_t_on', true);
+    cfg.PF.t_on      = getfield_default(cfg.PF,'t_on', 0);
+    cfg.PF.tau       = getfield_default(cfg.PF,'tau',  2.5);
+    cfg.PF.gain      = getfield_default(cfg.PF,'gain', 0.6);
     % constraint defaults
     if ~isfield(cfg,'cons') || ~isstruct(cfg.cons), cfg.cons = struct(); end
     if ~isfield(cfg.cons,'spring') || ~isstruct(cfg.cons.spring), cfg.cons.spring = struct(); end

--- a/simulate.m
+++ b/simulate.m
@@ -10,6 +10,7 @@ design_set = double(design_set);
                   'dP_orf_env',[],'c_lam',NaN,'dT_est',NaN,'metrics',struct());
     try
         % ---- guard + opsiyonel viskozite çarpanı
+        % ensure PF defaults (e.g., auto_t_on)
         cfg = ensure_cfg_defaults(cfg);
         if ~isempty(mu_mult) && isfinite(mu_mult) && mu_mult>0
             therm.mu_ref = therm.mu_ref * mu_mult;
@@ -47,8 +48,8 @@ therm.C_steel = m_steel_tot*therm.cp_steel;
 
     
        % ---- PF guard: t5 + 0.5
-[t5_sim,~] = arias_win(t, ag, 0.05, 0.95);
-cfg = set_pf_ton_if_auto(cfg, t5_sim, 0.5);   % <-- BURASI: t5_plot → t5_sim
+        [t5_sim,~] = arias_win(t, ag, 0.05, 0.95);
+        cfg = set_pf_ton_if_auto(cfg, t5_sim, 0.5);  % auto_t_on -> t_on=t5+0.5
 
         % ---- Çözüm (hız isteğe bağlı çıktıyla)
         [xD, aD, diag, vD] = mck_with_damper_adv(t, ag, M, Cstr, K, k_sd, geom, orf, hyd, therm, num, cfg);

--- a/viscous.m
+++ b/viscous.m
@@ -163,9 +163,9 @@ cfg.PF.auto_t_on  = true;   % true -> t_on = t5 + 0.5 via set_pf_ton_if_auto
 cfg.PF.t_on       = 0;      % auto_t_on=false ise manuel değer (s)
 cfg.PF.tau        = 0.9;    % 4.0 → 1.5  (önerim)
 cfg.PF.gain       = 1.7;    % 0.45 → 1.0 (önerim)
-cfg.on.pf_resistive_only = true;
+cfg.on.pf_resistive_only = true;  % sadece rezistif PF bileşeni kullan
 
-% Eksik/yanlış alanlar için güvenli tamamlayıcı (guard)
+% Eksik/yanlış alanlar için güvenli tamamlayıcı (guard; PF.auto_t_on dahil)
 cfg = ensure_cfg_defaults(cfg);
 
 %% -------------------- GA/Opt tasarım anahtarları ----------------------
@@ -1776,7 +1776,7 @@ end
 function cfg2 = cfg_with_ga(design_set,x,geom,sh,orf,hyd,therm,num,cfg)
     % simulate() tasarımı içerde decode ediyor; burada yalnız cfg’yi aynen geçiriyoruz.
     %#ok<INUSD>
-    cfg2 = ensure_cfg_defaults(cfg);
+    cfg2 = ensure_cfg_defaults(cfg);  % fills PF.auto_t_on, etc.
 end
 function [xbest, fbest, output, pop, scores, exitflag] = ga_call_compat(fhandle, lb, ub, IntCon, opts)
 % GA için sürüm-uyumlu çağrı (6/4/2 çıktı destekler)


### PR DESCRIPTION
## Summary
- ensure PF.auto_t_on and related fields default via getfield\_default
- document auto PF timing flag in simulate and viscous configs
- clarify cfg guards to cover new flags

## Testing
- `octave -qf --eval "ensure_cfg_defaults(struct());"` *(fails: command not found: octave)*

------
https://chatgpt.com/codex/tasks/task_e_68b0584e8b74832884c0c59b99ef2dcd