### PR TITLE
Refactor pressure force ramp weighting

### DIFF
--- a/pf_weight.m
+++ b/pf_weight.m
@@ -1,0 +1,12 @@
+function w = pf_weight(t, cfg)
+%PF_WEIGHT Time-dependent pressure-force ramp factor.
+%   w = PF_WEIGHT(t, cfg) returns the ramp weight for pressure-force
+%   activation. It supports scalar or vector inputs t. The weight ramps
+%   from 0 to 1 starting at cfg.PF.t_on with time constant cfg.PF.tau.
+%
+%   The result is multiplied by cfg.on.pressure_force so that the weight
+%   is zero when the pressure-force mechanism is disabled.
+
+    dt = max(t - cfg.PF.t_on, 0);
+    w = cfg.on.pressure_force * (1 - exp(-dt ./ max(cfg.PF.tau, 1e-6)));
+end


### PR DESCRIPTION
## Summary
- Inline pressure-force ramp calculation in `rhs` and remove `pf_weight_scalar`
- Add reusable `pf_weight` helper and replace `pf_weight_vec` calls
- Drop duplicated PF weight functions from `mck_with_damper_adv.m`

## Testing
- `octave -qf --eval "disp(pf_weight([0,1,2], struct('on',struct('pressure_force',1),'PF',struct(''t_on'',0,''tau'',1))))"`


------
https://chatgpt.com/codex/tasks/task_e_68b062a591cc832887833b1df4525b1f