### PR TITLE
feat: cache PSA computations for reuse

### DIFF
--- a/psa_cache.m
+++ b/psa_cache.m
@@ -1,0 +1,28 @@
+function val = psa_cache(action, key, val_in)
+%PSA_CACHE Persistent cache for PSA results.
+%   val = PSA_CACHE(action, key, val_in)
+%   Actions:
+%     'get'  - retrieve value for key (empty if not found)
+%     'set'  - store value and return it
+%     'clear'- clear all cached values
+    persistent cache
+    if isempty(cache)
+        cache = containers.Map('KeyType','char','ValueType','any');
+    end
+    switch action
+        case 'get'
+            if isKey(cache, key)
+                val = cache(key);
+            else
+                val = [];
+            end
+        case 'set'
+            cache(key) = val_in;
+            val = val_in;
+        case 'clear'
+            cache = containers.Map('KeyType','char','ValueType','any');
+            val = [];
+        otherwise
+            error('psa_cache:unknownAction', 'Unknown action %s', action);
+    end
+end

--- a/psa_hash.m
+++ b/psa_hash.m
@@ -1,0 +1,11 @@
+function key = psa_hash(t, ag, T_vec, zeta)
+%PSA_HASH Compute a hash string for PSA input combinations.
+%   key = PSA_HASH(t, ag, T_vec, zeta) returns an MD5 hash based on the
+%   provided vectors/scalars. This is used to cache PSA computations.
+    data = [];
+    if ~isempty(t),     data = [data; t(:)]; end
+    if ~isempty(ag),    data = [data; ag(:)]; end
+    if ~isempty(T_vec), data = [data; T_vec(:)]; end
+    if ~isempty(zeta),  data = [data; zeta(:)]; end
+    key = hash('md5', char(typecast(data,'uint8')).');
+end

--- a/sdof_PSA_band_avg_aug.m
+++ b/sdof_PSA_band_avg_aug.m
@@ -1,6 +1,12 @@
 function Sab = sdof_PSA_band_avg_aug(t, ag, T1, zeta, band_fac, Np)
 % Band ortalaması alınmış spektral ivme
     Tvec = linspace(band_fac(1)*T1, band_fac(2)*T1, Np);
-    Sa   = sdof_PSA_vec_aug_ode(t, ag, Tvec, zeta);
-    Sab  = mean(Sa);
+
+    % Önce önbellekte var mı kontrol et
+    key = psa_hash(t, ag, Tvec, zeta);
+    Sa  = psa_cache('get', key);
+    if isempty(Sa)
+        Sa = sdof_PSA_vec_aug_ode(t, ag, Tvec, zeta);
+    end
+    Sab = mean(Sa);
 end

--- a/sdof_PSA_vec_aug_ode.m
+++ b/sdof_PSA_vec_aug_ode.m
@@ -3,6 +3,13 @@ function Sa_vec = sdof_PSA_vec_aug_ode(t, ag, T_vec, zeta)
 % t: zaman vektörü, ag: yer ivmesi, T_vec: periyotlar, zeta: sönüm oranı
 
     T_vec = T_vec(:); Np = numel(T_vec);
+
+    % --- Önce önbelleği kontrol et ------------------------------------
+    key     = psa_hash(t, ag, T_vec, zeta);
+    Sa_vec  = psa_cache('get', key);
+    if ~isempty(Sa_vec), return; end
+
+    % Hesaplama
     wn = 2*pi./max(T_vec,eps);
     agf = griddedInterpolant(t, ag, 'linear','nearest');
 
@@ -21,6 +28,9 @@ function Sa_vec = sdof_PSA_vec_aug_ode(t, ag, T_vec, zeta)
                 - (ones(Nt,1)*(wn.'.^2)).*X ...
                 - ag(:)*ones(1,Np) );    % Nt x Np
     Sa_vec = max(Aabs,[],1).';
+
+    % Sonucu önbelleğe yaz
+    psa_cache('set', key, Sa_vec);
 end
 
 function dz = aug_rhs(tt,zz,wn,zeta,agf)


### PR DESCRIPTION
## Summary
- cache SDOF PSA results using hash-based map
- reuse cached PSA vectors in band-average function
- preserve per-record PSA values across GA iterations

## Testing
- `octave -q --eval "sdof_PSA_band_avg_aug(0:0.1:1, zeros(1,11), 1, 0.05, [0.5 2], 5);"` *(fails: 'griddedInterpolant' undefined)*


------
https://chatgpt.com/codex/tasks/task_e_68b0a260e75c8328af6486e0640aeac4