### PR TITLE
Use explicit md5 hashing for PSA cache

### DIFF
--- a/md5.m
+++ b/md5.m
@@ -1,0 +1,8 @@
+function h = md5(str)
+%MD5 Compute MD5 hash of input string, returning lowercase hex digest.
+%   h = MD5(str) returns the lowercase MD5 hash for the given string.
+    if isstring(str)
+        str = char(str);
+    end
+    h = lower(hash('md5', str));
+end

--- a/psa_hash.m
+++ b/psa_hash.m
@@ -7,5 +7,5 @@ function key = psa_hash(t, ag, T_vec, zeta)
     if ~isempty(ag),    data = [data; ag(:)]; end
     if ~isempty(T_vec), data = [data; T_vec(:)]; end
     if ~isempty(zeta),  data = [data; zeta(:)]; end
-    key = hash('md5', char(typecast(data,'uint8')).');
+    key = lower(md5(num2str(data(:)', '%.16g,')));
 end

--- a/viscous.m
+++ b/viscous.m
@@ -2038,5 +2038,5 @@ function key = hash_psa_prep(t_cells, a_cells, params)
         if ~isempty(a_cells{i}), buf = [buf; a_cells{i}(:)]; end
     end
     buf = [buf; params(:)];
-    key = hash('md5', char(typecast(buf, 'uint8')).');
+    key = lower(md5(num2str(buf(:)', '%.16g,')));
 end


### PR DESCRIPTION
## Summary
- Generate PSA cache keys via `md5(num2str(...))` for deterministic hashing
- Apply the same md5-based hashing strategy in `hash_psa_prep`
- Add a small `md5` helper returning lowercase hex digests

## Testing
- `octave -qf --eval "addpath(pwd); key1=psa_hash(1:3,4:6,[0.1 0.2],0.05); key2=psa_hash(1:3,4:6,[0.1 0.2],0.05); fprintf('%s %s %d\n', key1, key2, strcmp(key1,key2));"`
- `octave -qf --eval "addpath(pwd); key1=hash_psa_prep({[1:3]}, {[4:6]}, [0.1 0.2]); key2=hash_psa_prep({[1:3]}, {[4:6]}, [0.1 0.2]); fprintf('%s %s %d\n', key1, key2, strcmp(key1,key2));"`

------
https://chatgpt.com/codex/tasks/task_e_68b0a6341d508328b86feaa29f55fc7b