### PR TITLE
Fix hashing utilities to output lowercase hex

### DIFF
--- a/md5.m
+++ b/md5.m
@@ -4,5 +4,5 @@ function h = md5(str)
     if isstring(str)
         str = char(str);
     end
-    h = lower(hash('md5', str));
+    h = lower(hash('md5', str, 'hex'));
 end

--- a/psa_hash.m
+++ b/psa_hash.m
@@ -7,5 +7,5 @@ function key = psa_hash(t, ag, T_vec, zeta)
     if ~isempty(ag),    data = [data; ag(:)]; end
     if ~isempty(T_vec), data = [data; T_vec(:)]; end
     if ~isempty(zeta),  data = [data; zeta(:)]; end
-    key = lower(md5(num2str(data(:)', '%.16g,')));
+    key = md5(num2str(data(:)', '%.16g,'));
 end

--- a/viscous.m
+++ b/viscous.m
@@ -2038,5 +2038,5 @@ function key = hash_psa_prep(t_cells, a_cells, params)
         if ~isempty(a_cells{i}), buf = [buf; a_cells{i}(:)]; end
     end
     buf = [buf; params(:)];
-    key = lower(md5(num2str(buf(:)', '%.16g,')));
+    key = md5(num2str(buf(:)', '%.16g,'));
 end


### PR DESCRIPTION
## Summary
- ensure md5 wrapper uses `hash` with explicit `'hex'` output
- streamline PSA hashing by dropping redundant `lower` calls
- update PSA prep helper in `viscous` to rely on lowercase output

## Testing
- `octave --quiet --eval "psa_hash([1 2], [3 4], [0.1 0.2], 0.05)"`
- `octave --quiet --eval "hash_psa_prep({[1 2]}, {[3 4]}, [0.1 0.2])"`
- `octave --quiet viscous.m` *(fails: nested functions not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a94aa9bc8328811ddd93f480f42e